### PR TITLE
Update metadata file for MM5 SFCLAY_REV

### DIFF
--- a/sf_sfclayrev.meta
+++ b/sf_sfclayrev.meta
@@ -52,8 +52,8 @@
   kind = kind_phys
   intent = in
 [qv1d]
-  standard_name = specific_humidity_at_surface_adjacent_layer
-  long_name = water vapor specific humidity at lowest model layer
+  standard_name = water_vapor_mixing_ratio_at_surface_adjacent_layer
+  long_name =  water vapor mixing ratio at surface adjacent layer
   units = kg kg-1
   dimensions = (horizontal_loop_extent)
   type = real
@@ -418,9 +418,9 @@
   kind = kind_phys
   intent = in
 [svp1]
-  standard_name = saturation_vapor_pressure_constant_1
-  long_name = constant for saturation vapor pressure calculation
-  units = k Pa
+  standard_name = saturation_pressure_at_triple_point_of_water_in_kPa
+  long_name = saturation pressure at triple point of water in kPa
+  units = kPa
   dimensions = ()
   type = real
   kind = kind_phys
@@ -442,8 +442,8 @@
   kind = kind_phys
   intent = in
 [svpt0]
-  standard_name = saturation_vapor_pressure_constant_0
-  long_name = constant for saturation vapor pressure calculation
+  standard_name = temperature_at_zero_celsius
+  long_name = temperature at 0 degrees Celsius
   units = K
   dimensions = ()
   type = real 


### PR DESCRIPTION
Updates were based on discussions with Laura, and suggestions from Jimy to handle physical constants to calculate saturation vapor pressure of water (Bolton 1980).
In specific, modified:   `sf_sfclayrev.meta`
